### PR TITLE
Add health endpoint

### DIFF
--- a/src/apis/__init__.py
+++ b/src/apis/__init__.py
@@ -1,4 +1,5 @@
 from flask_restx import Api
+from .pong.pong_api import api as pong_api
 from .dataset.dataset_api import api as dataset_api
 from .resource.resource_api import api as resource_api
 
@@ -25,3 +26,6 @@ if "dataset" in enabled_endpoints:
 
 if "resource" in enabled_endpoints:
     api.add_namespace(resource_api, path="%s" % base_path)
+
+if "pong" in enabled_endpoints:
+    api.add_namespace(pong_api, path="%s" % base_path)

--- a/src/apis/__init__.py
+++ b/src/apis/__init__.py
@@ -1,5 +1,6 @@
 from flask_restx import Api
 from .pong.pong_api import api as pong_api
+from .health.health_api import api as health_api
 from .dataset.dataset_api import api as dataset_api
 from .resource.resource_api import api as resource_api
 
@@ -29,3 +30,6 @@ if "resource" in enabled_endpoints:
 
 if "pong" in enabled_endpoints:
     api.add_namespace(pong_api, path="%s" % base_path)
+
+if "health" in enabled_endpoints:
+    api.add_namespace(health_api, path="%s" % base_path)

--- a/src/apis/health/DependencyHealth.py
+++ b/src/apis/health/DependencyHealth.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from http import HTTPStatus
+import logging
+from typing import Optional
+
+import requests
+from requests.exceptions import RequestException, URLRequired
+
+
+@dataclass
+class DependencyHealth:
+    status_code: Optional[HTTPStatus]
+
+    def is_ok(self):
+        return self.status_code == HTTPStatus.OK
+
+
+@dataclass
+class Dependency:
+    config_key: str
+    health_url: str
+
+    def get_health(self, timeout_sec: float) -> DependencyHealth:
+        # try to get a response from self.health_url. on errors that are
+        # likely due to the dependency, set the http_status to None.
+        logging.info("Getting health response for '%s'" % self.health_url)
+
+        try:
+            health_response = requests.get(self.health_url, timeout=timeout_sec)
+        except (URLRequired, ValueError):
+            logging.exception("Cannot get health response for '%s'" % self.health_url)
+            raise
+        except RequestException:
+            logging.exception("Cannot get health respsonse for '%s'" % self.health_url)
+            http_status = None
+        else:
+            logging.info("Got response for '%s'" % self.health_url)
+            http_status = HTTPStatus(health_response.status_code)
+
+        return DependencyHealth(http_status)

--- a/src/apis/health/health_api.py
+++ b/src/apis/health/health_api.py
@@ -1,0 +1,47 @@
+import logging
+from typing import Tuple
+
+from flask import current_app
+from flask_restx import Namespace, Resource
+
+from apis.health.DependencyHealth import Dependency, DependencyHealth
+
+api = Namespace(
+    "Health",
+    description="Overall health of the API.",
+)
+
+
+@api.hide
+@api.route("health")
+class Health(Resource):
+    def get(this):
+        logging.info("Determining health of dependencies")
+        health_timeout_sec = current_app.config["HEALTH_TIMEOUT_SEC"]
+        dependencies = [
+            Dependency(
+                "SPARQL_ENDPOINT",
+                current_app.config["SPARQL_ENDPOINT_HEALTH_URL"],
+            )
+        ]
+        dependency_health: Tuple[Dependency, DependencyHealth] = [
+            (dependency, dependency.get_health(health_timeout_sec))
+            for dependency in dependencies
+        ]
+        dependencies_ok = all(health.is_ok() for _, health in dependency_health)
+
+        # ...
+        # additional health checks could be implemented here
+        # ...
+
+        logging.info("Determining overall health")
+        health = {
+            dependency.config_key: {
+                "url": dependency.health_url,
+                "statusCode": health.status_code,
+            }
+            for dependency, health in dependency_health
+        }
+
+        health_status = 200 if dependencies_ok else 500
+        return health, health_status

--- a/src/apis/health/health_api.py
+++ b/src/apis/health/health_api.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Tuple
+from typing import List, Tuple
 
 from flask import current_app
 from flask_restx import Namespace, Resource
@@ -15,7 +15,7 @@ api = Namespace(
 @api.hide
 @api.route("health")
 class Health(Resource):
-    def get(this):
+    def get(self):
         logging.info("Determining health of dependencies")
         health_timeout_sec = current_app.config["HEALTH_TIMEOUT_SEC"]
         dependencies = [
@@ -24,7 +24,7 @@ class Health(Resource):
                 current_app.config["SPARQL_ENDPOINT_HEALTH_URL"],
             )
         ]
-        dependency_health: Tuple[Dependency, DependencyHealth] = [
+        dependency_health: List[Tuple[Dependency, DependencyHealth]] = [
             (dependency, dependency.get_health(health_timeout_sec))
             for dependency in dependencies
         ]

--- a/src/apis/pong/pong_api.py
+++ b/src/apis/pong/pong_api.py
@@ -1,0 +1,10 @@
+from flask_restx import Namespace, Resource
+
+api = Namespace("Pong", description="Used for monitoring and DevOps.")
+
+
+@api.hide
+@api.route("pong", "ping")
+class Pong(Resource):
+    def get(self):
+        return "pong"

--- a/src/config/settings_example.py
+++ b/src/config/settings_example.py
@@ -16,7 +16,7 @@ class Config(object):
 
     STORAGE_BASE_URL = "http://flexstore.beng.nl:1234"
 
-    ENABLED_ENDPOINTS = ["resource", "dataset", "pong"]  # allow all by default
+    ENABLED_ENDPOINTS = ["resource", "dataset", "pong", "health"]  # allow all by default
 
     # profiles determine which schema is used for the linked data
     PROFILES = [
@@ -45,6 +45,9 @@ class Config(object):
     BENG_DATA_DOMAIN = "http://data.beeldengeluid.nl/"
 
     SPARQL_ENDPOINT = "https://cat.apis.beeldengeluid.nl/sparql"
+    SPARQL_ENDPOINT_HEALTH_URL = "https://cat.apis.beeldengeluid.nl/sparql"
 
     AUTH_USER = "very_special"
     AUTH_PASSWORD = "nobody_knows"
+
+    HEALTH_TIMEOUT_SEC = 5.0

--- a/src/config/settings_example.py
+++ b/src/config/settings_example.py
@@ -16,7 +16,7 @@ class Config(object):
 
     STORAGE_BASE_URL = "http://flexstore.beng.nl:1234"
 
-    ENABLED_ENDPOINTS = ["resource", "dataset"]  # allow all by default
+    ENABLED_ENDPOINTS = ["resource", "dataset", "pong"]  # allow all by default
 
     # profiles determine which schema is used for the linked data
     PROFILES = [

--- a/src/server.py
+++ b/src/server.py
@@ -43,16 +43,5 @@ api.init_app(
     description="Get RDF for open datasets and for resources in the NISV catalogue.",
 )
 
-"""------------------------------------------------------------------------------
-PING / HEARTBEAT ENDPOINT
-------------------------------------------------------------------------------"""
-
-
-@app.route("/ping")
-def ping():
-    logger.debug("Received ping")
-    return Response("pong", mimetype="text/plain")
-
-
 if __name__ == "__main__":
     app.run(host=app.config["APP_HOST"], port=app.config["APP_PORT"])

--- a/src/tests/unit_tests/apis/health/dependency_health_test.py
+++ b/src/tests/unit_tests/apis/health/dependency_health_test.py
@@ -1,0 +1,136 @@
+from http import HTTPStatus
+
+from mockito import mock, unstub, verifyStubbedInvocationsAreUsed, when
+import pytest
+import requests
+from requests.exceptions import (
+    ConnectionError,
+    HTTPError,
+    InvalidSchema,
+    Timeout,
+    TooManyRedirects,
+    URLRequired,
+)
+
+import apis.health.DependencyHealth
+from apis.health.DependencyHealth import Dependency, DependencyHealth
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_is_ok", [
+        # we expect ok for an ok http status
+        (HTTPStatus.OK, True),
+        # we don't expect ok for all http statuses other than OK
+        *[
+            (http_status.value, False)
+            for http_status in HTTPStatus if http_status != HTTPStatus.OK
+        ],
+        # we don't expect ok for a missing status (e.g. due to connection error)
+        (None, False),
+    ]
+)
+def test_dependency_health_is_ok(status_code: HTTPStatus, expected_is_ok: bool):
+    try:
+        dependency_health = DependencyHealth(status_code)
+        assert dependency_health.is_ok() == expected_is_ok
+    finally:
+        unstub()
+
+
+TEST_CONFIG_KEY = "EXAMPLE_HEALTH_ENDPOINT"
+TEST_HEALTH_URL = "https://example.com/health"
+
+
+@pytest.mark.parametrize(
+    "config_key, health_url, requests_response, requests_exception, expected_dependency_health, expected_exception",
+    [
+        # if requests returns a response, its status_code should be returned
+        *[
+            (
+                TEST_CONFIG_KEY,
+                TEST_HEALTH_URL,
+                mock({"body": "", "status_code": http_status.value}, spec=requests.Response),
+                None,
+                DependencyHealth(http_status.value),
+                None
+            )
+            for http_status in HTTPStatus
+        ],
+        # if requests throws server-related exceptions, None should be returned
+        (
+            TEST_CONFIG_KEY,
+            TEST_HEALTH_URL,
+            None,
+            ConnectionError,
+            DependencyHealth(None),
+            None,
+        ),
+        (
+            TEST_CONFIG_KEY,
+            TEST_HEALTH_URL,
+            None,
+            HTTPError,
+            DependencyHealth(None),
+            None,
+        ),
+        (
+            TEST_CONFIG_KEY,
+            TEST_HEALTH_URL,
+            None,
+            TooManyRedirects,
+            DependencyHealth(None),
+            None,
+        ),
+        (TEST_CONFIG_KEY, TEST_HEALTH_URL, None, Timeout, DependencyHealth(None), None),
+        # if requests throws client-related exceptions, they should be raised
+        (TEST_CONFIG_KEY, TEST_HEALTH_URL, None, InvalidSchema, None, InvalidSchema),
+        (TEST_CONFIG_KEY, TEST_HEALTH_URL, None, URLRequired, None, URLRequired),
+        # general exceptions should be raised as well
+        (TEST_CONFIG_KEY, TEST_HEALTH_URL, None, OverflowError, None, OverflowError),
+        (TEST_CONFIG_KEY, TEST_HEALTH_URL, None, Exception, None, Exception),
+    ],
+)
+def test_dependency(
+    config_key: str,
+    health_url: str,
+    requests_response: requests.Response,
+    requests_exception: Exception,
+    expected_dependency_health: DependencyHealth,
+    expected_exception: Exception,
+):
+    try:
+        dependency = Dependency(config_key, health_url)
+        health_timeout_sec = 5.0
+
+        # test __init__ and accessors
+        assert dependency.config_key == TEST_CONFIG_KEY
+        assert dependency.health_url == TEST_HEALTH_URL
+
+        # test get_dependency_health
+        if requests_exception:
+            when(apis.health.DependencyHealth.requests)\
+                .get(TEST_HEALTH_URL, timeout=health_timeout_sec)\
+                .thenRaise(requests_exception)
+        else:
+            when(apis.health.DependencyHealth.requests)\
+                .get(TEST_HEALTH_URL, timeout=health_timeout_sec)\
+                .thenReturn(requests_response)
+        if expected_dependency_health:
+            health = dependency.get_health(health_timeout_sec)
+            assert health == expected_dependency_health
+        elif expected_exception:
+            try:
+                dependency.get_health(health_timeout_sec)
+            except expected_exception:
+                # we got the expected_exception
+                assert True
+            except Exception:
+                # we got an unexcpected exception
+                assert False
+        else:
+            # this shouldn't happen, get_health() should return or raise
+            assert False
+
+    finally:
+        verifyStubbedInvocationsAreUsed()
+        unstub()

--- a/src/tests/unit_tests/apis/pong/pong_api_test.py
+++ b/src/tests/unit_tests/apis/pong/pong_api_test.py
@@ -1,0 +1,11 @@
+from mockito import unstub
+
+from apis.pong.pong_api import Pong
+
+
+def test_get_pong():
+    try:
+        pong = Pong()
+        assert pong.get() == "pong"
+    finally:
+        unstub()

--- a/src/util/base_util.py
+++ b/src/util/base_util.py
@@ -52,6 +52,7 @@ def validate_config(config, validate_file_paths=True):
             assert ep in [
                 "dataset",
                 "resource",
+                "pong",
             ], "ENABLED_ENDPOINTS: invalid endpoint ID"
 
         assert __check_setting(

--- a/src/util/base_util.py
+++ b/src/util/base_util.py
@@ -53,6 +53,7 @@ def validate_config(config, validate_file_paths=True):
                 "dataset",
                 "resource",
                 "pong",
+                "health",
             ], "ENABLED_ENDPOINTS: invalid endpoint ID"
 
         assert __check_setting(
@@ -63,6 +64,9 @@ def validate_config(config, validate_file_paths=True):
         assert __check_setting(config, "SPARQL_ENDPOINT", str), "SPARQL_ENDPOINT"
         assert validators.url(config["SPARQL_ENDPOINT"]), "SPARQL_ENDPOINT invalid URL"
 
+        assert __check_setting(config, "SPARQL_ENDPOINT_HEALTH_URL", str), "SPARQL_ENDPOINT_HEALTH_URL"
+        assert validators.url(config["SPARQL_ENDPOINT_HEALTH_URL"]), "SPARQL_ENDPOINT_HEALTH_URL invalid URL"
+
         assert __check_setting(config, "BENG_DATA_DOMAIN", str), "BENG_DATA_DOMAIN"
         assert validators.url(
             config["BENG_DATA_DOMAIN"]
@@ -70,6 +74,8 @@ def validate_config(config, validate_file_paths=True):
 
         assert __check_setting(config, "AUTH_USER", str), "AUTH_USER"
         assert __check_setting(config, "AUTH_PASSWORD", str), "AUTH_PASSWORD"
+
+        assert __check_setting(config, "HEALTH_TIMEOUT_SEC", float), "HEALTH_TIMEOUT_SEC"
 
         if validate_file_paths:
             assert __validate_file_paths(


### PR DESCRIPTION
Possibly a bit too much for such a simple endpoint, but trying to generalize and adopt existing patterns did help me a lot to get acquainted with it. Let me know if you have any questions!

~Before merging the relevant config should be present. See https://github.com/beeldengeluid/x-omgeving/pull/601 for that.~ (done)

Closes https://github.com/beeldengeluid/beng-lod-server/issues/190.


Testing checklist:
- Copy the config added to `settings-example.py` to your config.
- Start the server
- Check the response at `/ping` `/pong` and most imporantly `/health`.