### PR TITLE
added accept types as drowpdown to swagger UI

### DIFF
--- a/src/apis/gtaa/gtaa_api.py
+++ b/src/apis/gtaa/gtaa_api.py
@@ -30,6 +30,9 @@ api = Namespace(
     endpoint="gtaa_stuff",
 )
 class GTAAAPI(Resource):
+    """Serve the RDF for the GTAA SKOS Concepts in the format that was requested."""
+
+    @api.produces([mt.value for mt in MimeType])
     def get(self, identifier):
 
         gtaa_uri = f'{current_app.config.get("BENG_DATA_DOMAIN")}gtaa/{identifier}'

--- a/src/apis/resource/resource_api.py
+++ b/src/apis/resource/resource_api.py
@@ -32,6 +32,9 @@ api = Namespace(
     endpoint="dereference",
 )
 class ResourceAPI(Resource):
+    """Serve the RDF for the media catalog resources in the format that was requested."""
+
+    @api.produces([mt.value for mt in MimeType])
     def get(self, identifier, cat_type="program"):
         lod_url = None
         try:


### PR DESCRIPTION
small change enabling content negotiation in the swagger UI. Something that has been missing for a long time. It was just as easy as adding the 'produces' decorator with the list of provided mime_types.