### PR TITLE
311 load datacatalog from the triple store instead of local file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ resource/datacatalogfromspreadsheet-a5ccabb0919f.json
 /src/util/simple_test_script.py
 log
 .mypy_cache
+last_request.json


### PR DESCRIPTION
This PR makes it possible that when a new data catalog is loaded to the triple store, the beng-lod-server will pick up the changes whenever the expiration date is done. Currently, the default is 60 minutes, which seemed reasonable. 
When a new data catalog is loaded, it will remain in memory for the expiration time. During that time there will not have to be sent many requests to the triple store if datasets are requested. At the same time whenever the data catalog is refreshed it will take maximum of an hour before any changes are available in the beng-lod-server. Also, when loading a new data catalog, one doesn't have to be worried that requests during loading time trigger erroneous response (the time the triples are being loaded is already a very small period of time for 415 triples).

