### PR TITLE
Fix missing GPP url for seasons

### DIFF
--- a/src/models/BaseRdfConcept.py
+++ b/src/models/BaseRdfConcept.py
@@ -65,11 +65,12 @@ class BaseRdfConcept:
                     parent_id = parents.get("parent_id")
                     series_urn = f"urn:vme:default:series:{parent_id}"
 
-            path = None
-            if series_urn is not None:
-                season_urn = f"urn:vme:default:season:{daan_id}"
-                path = "/".join(["series", series_urn, season_urn])
-                return None  # seasons without series do not have a GPP landing page
+            # seasons without series do not have a GPP landing page
+            if series_urn is None:
+                return None
+
+            season_urn = f"urn:vme:default:season:{daan_id}"
+            path = "/".join(["series", series_urn, season_urn])
             parts = (url_parts.scheme, url_parts.netloc, path, "", "", "")
             return urlunparse(parts)
 


### PR DESCRIPTION
I tried writing a unit test for this case as well, but I didn't see how to do so without some refactoring first (which I wanted to avoid for now).

Tested manually for `/id/season/2102201030327767631`.