### PR TITLE
Remove flask-restx workaround.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,14 +17,13 @@ types-flask-cors = "==3.0.10"
 [packages]
 lxml = "==4.9.1"
 Flask-Cors = "==3.0.10"
-flask-restx = "==1.0.3"
 requests = "==2.28.1"
 rdflib = "==6.2.0"
 numpy = "==1.23.5"
 elasticsearch = "==7.17.7"
 flask = "==2.1.3"
 validators = "==0.20.0"
-werkzeug = "==2.1.2"
+flask-restx = "==1.0.3"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5093a7f44a83ef15aa59d0805f2dbd737b1112d125ce307b2ae41e0c43221961"
+            "sha256": "e441e4c04b661f309938bb24eb87491cc86277ed6e914fd11e71df9ee447617a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,7 +21,6 @@
                 "sha256:1d2b7ef82963909e93c4f24ce48d4de9e66009a21bf1c1e1c85bdd0812fe412f",
                 "sha256:72e3117667eedf66951bb2d93f4296a56b94b078a8a95905a052611fb3f1b973"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==9.0.1"
         },
         "attrs": {
@@ -413,11 +412,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:1ce08e8093ed67d638d63879fd1ba3735817f7a80de3674d293f5984f25fb6e6",
-                "sha256:72a4b735692dd3135217911cbeaa1be5fa3f62bffb8745c5215420a03dc55255"
+                "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f",
+                "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"
             ],
-            "index": "pypi",
-            "version": "==2.1.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.2.2"
         },
         "zipp": {
             "hashes": [


### PR DESCRIPTION
We had to install a specific version of werkzeug, a flask-restx dependency, since the latest wasn't compatible with flask-restx. Now it is, so we can undo this work.

Commands:
```
pipenv uninstall flask-restx
pipenv uninstall werkzeug
pipenv install 'flask-restx==1.0.3'
```