### PR TITLE
fix for the multilingual preflabels

### DIFF
--- a/src/models/BaseRdfConcept.py
+++ b/src/models/BaseRdfConcept.py
@@ -24,7 +24,7 @@ class BaseRdfConcept:
         self._classes = None
         self.itemNode = None
         self.classUri = None
-        self.graph = Graph()
+        self.graph = Graph(bind_namespaces="core")
         self.graph.namespace_manager.bind("skos", SKOS)
         self.graph.namespace_manager.bind("gtaa", Namespace(self._model.GTAA_NAMESPACE))
 

--- a/src/models/SDORdfConcept.py
+++ b/src/models/SDORdfConcept.py
@@ -454,13 +454,14 @@ class SDORdfConcept(BaseRdfConcept):
                         )
                     )
 
-                    self.graph.add(
-                        (
-                            skos_concept_node,
-                            SKOS.prefLabel,
-                            Literal(concept_label, lang="nl"),
-                        )
-                    )
+                    # CANNOT DO THIS, because the flex store doesn't provide language attributes
+                    # self.graph.add(
+                    #     (
+                    #         skos_concept_node,
+                    #         SKOS.prefLabel,
+                    #         Literal(concept_label, lang="nl"),
+                    #     )
+                    # )
                     break
 
         return skos_concept_node

--- a/src/templates/resource.html
+++ b/src/templates/resource.html
@@ -23,7 +23,7 @@
 						<a title="&lt;{{item.o.uri}}&gt;" href="{{item.o.uri}}" target="_blank" id="header_rdf_type">{{item.o.prefix}}:<span class="fw-bold">{{item.o.property}}</span></a>
 					{% else %}
 						<a class="link-light" title="&lt;{{item.o.uri}}&gt;" href="{{item.o.uri}}" target="_blank">&lt;{{item.o.namespace}}<span class="fw-bold">{{item.o.property}}</span>&gt;</a><br>
-					{% endif %}
+					{% endif %}	
 				{% endfor %}
 			</div>
 		</div>
@@ -59,7 +59,7 @@
 					<div class="col py-2 border-bottom">
 						<a title="&lt;http://www.w3.org/2008/05/skos-xl#literalForm&gt;" href="http://www.w3.org/2008/05/skos-xl#literalForm" target="_blank">skosxl:<span class="fw-bold">literalForm</span></a>
 					</div>
-					<div class="col py-2 border-bottom">{{item.o.literal_form|first}}</div>
+					<div class="col py-2 border-bottom">{{ item.o.literal_form|first }}</div>
 				</div>
 			{% elif item.p.uri == 'https://schema.org/license' %}
 				<a title="&lt;{{item.o.uri}}&gt;" href="{{item.o.uri}}" target="_blank">{{item.o.uri}}</a>
@@ -86,16 +86,18 @@
 					<div class="col py-2 border-bottom">
 						<a title="&lt;{{bnode.pred.uri}}&gt;" href="{{bnode.pred.uri}}" target="_blank">{{bnode.pred.prefix}}:<span class="fw-bold">{{bnode.pred.property}}</span></a>
 					</div>
-					<div class="col py-2 border-bottom">
-						{% if bnode.obj.uri is defined %}
-							{% if bnode.obj.uri.startswith('http://data.beeldengeluid.nl/gtaa/') %}
-								<a title="&lt;{{bnode.obj.uri}}&gt;" href="{{bnode.obj.uri}}" target="_blank">{{ bnode.obj.pref_label|first }}</a>
+					{% if bnode.obj.uri is defined %}
+						<div class="col py-2 border-bottom">
+							{% if bnode.obj.uri.startswith('http://data.beeldengeluid.nl/gtaa/') and bnode.obj.pref_label|length %}
+								<a title="&lt;{{bnode.obj.uri}}&gt;" href="{{bnode.obj.uri}}" target="_blank">{{bnode.obj.pref_label|first}}</a>
 							{% else %}
 								<a title="&lt;{{bnode.obj.uri}}&gt;" href="{{bnode.obj.uri}}" target="_blank">{{bnode.obj.prefix}}:<span class="fw-bold">{{bnode.obj.property}}</span></a>
 							{% endif %}
-						{% else %}{{bnode.obj}}
-						{% endif %}
-					</div>
+						</div>
+					{% endif %}
+					{% if bnode.obj.label is defined and bnode.obj.label|length %}
+						<div class="col-6 py-2 border-bottom">{{bnode.obj.label}}</div>
+					{% endif %}
 				</div>
 			{% endfor %}
 		</div>

--- a/src/templates/resource.html
+++ b/src/templates/resource.html
@@ -23,7 +23,7 @@
 						<a title="&lt;{{item.o.uri}}&gt;" href="{{item.o.uri}}" target="_blank" id="header_rdf_type">{{item.o.prefix}}:<span class="fw-bold">{{item.o.property}}</span></a>
 					{% else %}
 						<a class="link-light" title="&lt;{{item.o.uri}}&gt;" href="{{item.o.uri}}" target="_blank">&lt;{{item.o.namespace}}<span class="fw-bold">{{item.o.property}}</span>&gt;</a><br>
-					{% endif %}	
+					{% endif %}
 				{% endfor %}
 			</div>
 		</div>
@@ -59,7 +59,7 @@
 					<div class="col py-2 border-bottom">
 						<a title="&lt;http://www.w3.org/2008/05/skos-xl#literalForm&gt;" href="http://www.w3.org/2008/05/skos-xl#literalForm" target="_blank">skosxl:<span class="fw-bold">literalForm</span></a>
 					</div>
-					<div class="col py-2 border-bottom">{{ item.o.literal_form|first }}</div>
+					<div class="col py-2 border-bottom">{{item.o.literal_form|first}}</div>
 				</div>
 			{% elif item.p.uri == 'https://schema.org/license' %}
 				<a title="&lt;{{item.o.uri}}&gt;" href="{{item.o.uri}}" target="_blank">{{item.o.uri}}</a>

--- a/src/tests/unit_tests/apis/resource/sdo_storage_lod_handler_test.py
+++ b/src/tests/unit_tests/apis/resource/sdo_storage_lod_handler_test.py
@@ -67,9 +67,6 @@ def test_get_storage_record__ob_scene_payload(application_settings, i_ob_scene_p
         g = Graph()
         g.parse(data=resp, format=mt.to_ld_format())
 
-        # test for number of triples
-        assert len(g) == 31
-
         # test for existence of some triples
         type_triple = (
             URIRef("http://data.beeldengeluid.nl/id/scene/2101703040124290024"),
@@ -83,8 +80,6 @@ def test_get_storage_record__ob_scene_payload(application_settings, i_ob_scene_p
             SDO.license,
             URIRef("http://rightsstatements.org/vocab/CNE/1.0/"),
         )
-        print(license_triple)
-        print(g)
         assert license_triple in g
 
         ob_uri_triple = (

--- a/src/tests/unit_tests/util/ld_util_test.py
+++ b/src/tests/unit_tests/util/ld_util_test.py
@@ -300,10 +300,7 @@ def test_json_iri_bnode_from_rdf_graph(program_rdf_graph_with_bnodes):
                             ]
                         )
                     if isinstance(bnode_content, Literal):
-                        assert all(
-                            x in bnode_content["obj"]
-                            for x in ["label"]
-                        )                   
+                        assert all(x in bnode_content["obj"] for x in ["label"])
 
     finally:
         unstub()

--- a/src/tests/unit_tests/util/ld_util_test.py
+++ b/src/tests/unit_tests/util/ld_util_test.py
@@ -4,7 +4,7 @@ import pytest
 # the following SDO import generates a warning, see
 # https://github.com/RDFLib/rdflib/issues/1830
 
-from rdflib import Graph
+from rdflib import Graph, URIRef, Literal
 from rdflib.namespace import SDO, RDF
 from rdflib.compare import to_isomorphic
 import requests
@@ -288,16 +288,22 @@ def test_json_iri_bnode_from_rdf_graph(program_rdf_graph_with_bnodes):
                     bnode_content["obj"], dict
                 )
                 if isinstance(bnode_content["obj"], dict):
-                    assert all(
-                        x in bnode_content["obj"]
-                        for x in [
-                            "uri",
-                            "prefix",
-                            "namespace",
-                            "property",
-                            "pref_label",
-                        ]
-                    )
+                    if isinstance(bnode_content, URIRef):
+                        assert all(
+                            x in bnode_content["obj"]
+                            for x in [
+                                "uri",
+                                "prefix",
+                                "namespace",
+                                "property",
+                                "pref_label",
+                            ]
+                        )
+                    if isinstance(bnode_content, Literal):
+                        assert all(
+                            x in bnode_content["obj"]
+                            for x in ["label"]
+                        )                   
 
     finally:
         unstub()

--- a/src/util/ld_util.py
+++ b/src/util/ld_util.py
@@ -118,7 +118,7 @@ def get_triples_for_lod_resource_from_rdf_store(
     """
     query_construct = (
         f"CONSTRUCT {{ ?s ?p ?o }} WHERE {{ VALUES ?s {{ <{resource_url}> }} "
-        f"?s ?p ?o FILTER(!ISBLANK(?o)) }}"
+        f"?s ?p ?o FILTER(!ISBLANK(?o)) FILTER(?p != skos:prefLabel)}}"
     )
 
     return sparql_construct_query(sparql_endpoint, query_construct)

--- a/src/util/ld_util.py
+++ b/src/util/ld_util.py
@@ -286,7 +286,7 @@ def json_header_from_rdf_graph(
                 "title": [
                     str(label)
                     for label in rdf_graph.objects(URIRef(resource_url), SKOS.prefLabel)
-                    if label.language == "nl"
+                    if Literal(label).language == "nl"
                 ]
                 + [
                     str(name)
@@ -332,7 +332,7 @@ def json_iri_iri_from_rdf_graph(
                 "o": {
                     "uri": str(o),
                     "literal_form": [
-                        f"{str(lf)} @{lf.language}"
+                        f"{str(lf)} @{Literal(lf).language}"
                         for lf in rdf_graph.objects(
                             o, URIRef(f"{SKOSXL_NS}literalForm")
                         )
@@ -343,7 +343,7 @@ def json_iri_iri_from_rdf_graph(
                     "pref_label": [
                         str(label)
                         for label in rdf_graph.objects(o, SKOS.prefLabel)
-                        if label.language == "nl"
+                        if Literal(label).language == "nl"
                     ],
                     "parent_label": [
                         str(label) for label in rdf_graph.objects(o, SDO.name)
@@ -453,7 +453,7 @@ def json_iri_bnode_from_rdf_graph(
                             ),
                             "property": rdf_graph.compute_qname(str(bnode_obj))[2],
                             "pref_label": [
-                                f"{str(pl)} @{pl.language}"
+                                f"{str(pl)} @{Literal(pl).language}"
                                 for pl in rdf_graph.objects(bnode_obj, SKOS.prefLabel)
                             ],
                         }


### PR DESCRIPTION
The GTAA code database stores labels with a language attribute. The DAAn database uses a copy of these labels in local lists. It is unknown whether the language attribute is store in DAAN. 

The flex store provides labels coming from the DAAN database. Where these labels have a language attribute in the thesaurus, this language attribute is lost, either in the internal DAAN database, or in the mapping to the flex store. 

To prevent labels to enter the LOD domain with the wrong language attribute, we remove the mapping in the beng-lod-server as it was before. The skos concept uri is stored though. It can be used when getting the triples from the rdf store, including the langstring with the right attributes.

In the lod-view pages we provide labels including their language attribute like "somelabel @nl", at least when they are part of the concept. When referring to other concepts, only the prefLabel (nl) is shown, without lang attribute (maybe not completely consistent, but hell..).



